### PR TITLE
Use mindre-subtle for hl-line

### DIFF
--- a/mindre-theme.el
+++ b/mindre-theme.el
@@ -64,10 +64,6 @@
   "Highlight color is used to highlight part of the screen."
   :type 'color :group 'mindre)
 
-(defcustom mindre-highlight-alt "#ECEFF1"
-  "Lighter highlight color used to highlight part of the screen."
-  :type 'color :group 'mindre)
-
 (defcustom mindre-subtle "#ECEFF1"
   "Subtle color is used to suggest a physical area on the screen."
   :type 'color :group 'mindre)
@@ -252,8 +248,8 @@ Commonly used for types"
  '(italic                      ((t (:inherit mindre-faded))))
  '(bold-italic                 ((t (:inherit mindre-strong))))
  '(region                      ((t (:inherit highlight))))
- '(fringe                      ((t (:inherit (mindre-faded)))))
- '(hl-line                     ((t (:inherit highlight))))
+ '(fringe                      ((t (:inherit mindre-faded))))
+ '(hl-line                     ((t (:inherit mindre-subtle))))
  '(link                        ((t (:inherit mindre-salient))))
  ;; TODO: Add option for turning mixed-fonts on/off
  ;'(fixed-pitch                 ((t (:inherit default))))


### PR DESCRIPTION
Hello, I think this is a bit better solution for hl-line since this do not clash with highlight face which is also used for selection. I've also removed `mindre-highlight-alt` since it wasn't used anywhere and its color is the same as `mindre-subtle`.

Best wishes,
alternateved