### PR TITLE
Fix Obsolete Since Emacs 0.1

### DIFF
--- a/mindre-theme.el
+++ b/mindre-theme.el
@@ -242,7 +242,7 @@ Takes care of adding or removing hooks when the
   (load-theme 'mindre t)
   (run-hooks 'mindre-after-load-hook))
 
-(make-obsolete 'mindre 'load-theme "0.1")
+;;(make-obsolete 'mindre 'load-theme "0.1")
 
 ;; --- Faces ---------------------------------------------------------
 (mindre-with-color-variables


### PR DESCRIPTION
Loading the theme causes Emacs to say it has been obsolete since Emacs 0.1.